### PR TITLE
Fix setup command syntax - use spaces not hyphens

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ RUN pip install git+https://github.com/EvanSchalton/Tmux-Orchestrator.git
 #### Quick Setup for Your Project
 ```bash
 # After installation, set up VS Code integration
-tmux-orc setup-vscode .
+tmux-orc setup vscode .
 
 # Create a PRD for your project
 tmux-orc tasks create my-project
@@ -295,7 +295,7 @@ For projects using Poetry:
   "postCreateCommand": [
     "apt-get update && apt-get install -y tmux",
     "pip install git+https://github.com/EvanSchalton/Tmux-Orchestrator.git",
-    "tmux-orc setup-all",
+    "tmux-orc setup all",
     "tmux-orc orchestrator start"
   ],
   

--- a/devcontainer-template.json
+++ b/devcontainer-template.json
@@ -10,7 +10,7 @@
     "postCreateCommand": [
       "apt-get update && apt-get install -y tmux",
       "pip install git+https://github.com/EvanSchalton/Tmux-Orchestrator.git",
-      "tmux-orc setup-all",
+      "tmux-orc setup all",
       "tmux-orc orchestrator start"
     ],
     "remoteEnv": {
@@ -21,8 +21,8 @@
     "postCreateCommand": [
       "apt-get update && apt-get install -y tmux",
       "pip install git+https://github.com/EvanSchalton/Tmux-Orchestrator.git",
-      "tmux-orc setup-vscode .",
-      "tmux-orc setup-claude-code"
+      "tmux-orc setup vscode .",
+      "tmux-orc setup claude-code"
     ],
     "customizations": {
       "vscode": {

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -107,7 +107,7 @@ Update any references to use the new paths.
 - Use `tmux-orc tasks` commands
 
 ### Enhanced CLI
-- `tmux-orc setup-claude-code` - Install slash commands
+- `tmux-orc setup claude-code` - Install slash commands
 - `tmux-orc execute <prd>` - Execute PRD with custom team
 - `tmux-orc tasks` - Complete task management
 - `tmux-orc team compose` - Plan custom teams

--- a/docs/setup/quickstart.md
+++ b/docs/setup/quickstart.md
@@ -62,7 +62,7 @@ For a complete devcontainer setup with Tmux Orchestrator:
   "postCreateCommand": [
     "apt-get update && apt-get install -y tmux",
     "pip install git+https://github.com/EvanSchalton/Tmux-Orchestrator.git",
-    "tmux-orc setup-all",
+    "tmux-orc setup all",
     "tmux-orc orchestrator start"
   ],
   
@@ -93,7 +93,7 @@ pip install git+https://github.com/EvanSchalton/Tmux-Orchestrator.git
 ### Setup Claude Code Integration
 After installation, set up slash commands and MCP server:
 ```bash
-tmux-orc setup-claude-code
+tmux-orc setup claude-code
 ```
 
 This creates:

--- a/docs/templates/install-template.sh
+++ b/docs/templates/install-template.sh
@@ -26,13 +26,13 @@ tmux-orc setup
 # Optional: Setup VS Code integration
 if [ -d ".vscode" ] || [ "$1" == "--vscode" ]; then
     echo "🔧 Setting up VS Code integration..."
-    tmux-orc setup-vscode .
+    tmux-orc setup vscode .
 fi
 
 # Optional: Setup Claude Code integration
 if [ -d "$HOME/.continue" ] || [ "$1" == "--claude" ]; then
     echo "🔧 Setting up Claude Code integration..."
-    tmux-orc setup-claude-code
+    tmux-orc setup claude-code
 fi
 
 echo "✅ Tmux Orchestrator installation complete!"

--- a/docs/workflows/end-to-end.md
+++ b/docs/workflows/end-to-end.md
@@ -13,13 +13,13 @@
    pip install -e .
    ```
 
-3. **User runs `tmux-orc setup-claude-code`**
+3. **User runs `tmux-orc setup claude-code`**
    - Installs slash commands to `~/.continue/commands/`
    - Configures MCP server in `~/.continue/config/mcp.json`
    - Creates `CLAUDE.md` in workspace with instructions
    - User must restart Claude Code to load slash commands
 
-3.b **User optionally runs `tmux-orc setup-vscode`**
+3.b **User optionally runs `tmux-orc setup vscode`**
    - Creates `.vscode/tasks.json` with orchestrator commands
    - Adds "Open All Agents" task
    - Adds "Show Daemon Logs" task

--- a/tmux_orchestrator/cli/setup_claude.py
+++ b/tmux_orchestrator/cli/setup_claude.py
@@ -29,9 +29,9 @@ def setup(ctx: click.Context) -> None:
 
     Examples:
         tmux-orc setup                  # Check system requirements
-        tmux-orc setup-claude-code       # Setup Claude Code integration
-        tmux-orc setup-vscode ./project  # Configure VS Code
-        tmux-orc setup-all              # Run all setup commands
+        tmux-orc setup claude-code      # Setup Claude Code integration
+        tmux-orc setup vscode ./project # Configure VS Code
+        tmux-orc setup all              # Run all setup commands
     """
     if ctx.invoked_subcommand is None:
         # If no subcommand provided, run check-requirements
@@ -125,9 +125,9 @@ def check_requirements() -> None:
     console.print("\n[green]✓ All system requirements met![/green]")
     console.print("\nNext steps:")
     console.print(
-        "1. Set up Claude Code integration: [cyan]tmux-orc setup-claude-code[/cyan]")
-    console.print("2. Configure VS Code: [cyan]tmux-orc setup-vscode[/cyan]")
-    console.print("3. Or run all setups: [cyan]tmux-orc setup-all[/cyan]")
+        "1. Set up Claude Code integration: [cyan]tmux-orc setup claude-code[/cyan]")
+    console.print("2. Configure VS Code: [cyan]tmux-orc setup vscode[/cyan]")
+    console.print("3. Or run all setups: [cyan]tmux-orc setup all[/cyan]")
 
 
 @setup.command(name='claude-code')
@@ -143,9 +143,9 @@ def setup_claude_code(claude_dir: str, force: bool) -> None:
     - Auto-restart of Claude Code if needed
 
     Examples:
-        tmux-orc setup-claude-code
-        tmux-orc setup-claude-code --force
-        tmux-orc setup-claude-code --claude-dir /custom/path
+        tmux-orc setup claude-code
+        tmux-orc setup claude-code --force
+        tmux-orc setup claude-code --claude-dir /custom/path
     """
     claude_path = Path(claude_dir)
 
@@ -323,8 +323,8 @@ def setup_vscode(project_dir: str, force: bool) -> None:
     - Workspace settings
 
     Examples:
-        tmux-orc setup-vscode
-        tmux-orc setup-vscode ./my-project --force
+        tmux-orc setup vscode
+        tmux-orc setup vscode ./my-project --force
     """
     from tmux_orchestrator.cli.setup import setup_vscode_tasks
 
@@ -363,8 +363,8 @@ def setup_all(force: bool) -> None:
     - Shell completions
 
     Examples:
-        tmux-orc setup-all
-        tmux-orc setup-all --force
+        tmux-orc setup all
+        tmux-orc setup all --force
     """
     console.print(
         "[bold blue]Running complete environment setup...[/bold blue]\n")
@@ -396,7 +396,7 @@ def check_setup() -> None:
     - Slash command installation
 
     Examples:
-        tmux-orc setup-check
+        tmux-orc setup check
     """
     console.print("[bold]Checking Tmux Orchestrator Setup[/bold]\n")
 
@@ -484,10 +484,10 @@ def check_setup() -> None:
         if "Claude Code Directory" in missing:
             console.print("• Install Claude Code and run it once")
         if "Slash Commands" in missing or "MCP Configuration" in missing:
-            console.print("• Run: tmux-orc setup-claude-code")
+            console.print("• Run: tmux-orc setup claude-code")
         if "VS Code Tasks" in missing:
-            console.print("• Run: tmux-orc setup-vscode")
+            console.print("• Run: tmux-orc setup vscode")
         if "Workspace CLAUDE.md" in missing:
-            console.print("• Run: tmux-orc setup-claude-code --force")
+            console.print("• Run: tmux-orc setup claude-code --force")
     else:
         console.print("\n[green]✓ All components properly configured![/green]")


### PR DESCRIPTION
The correct syntax is:
- tmux-orc setup claude-code (not setup-claude-code)
- tmux-orc setup vscode (not setup-vscode)
- tmux-orc setup all (not setup-all)

This is because 'setup' is a command group with subcommands, not a prefix for hyphenated commands.

🤖 Generated with [Claude Code](https://claude.ai/code)